### PR TITLE
Fix typo in parameter substitution.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ for FILE in ${SOURCE_PATH}; do
             -u${INPUT_USERNAME}:${INPUT_APIKEY} \
             -H "X-Bintray-Package:${PACKAGE}" \
             -H "X-Bintray-Version:${VERSION}" \
-            -H "X-Bintray-Override:${INPUT_OVERRIDE:0}" \
+            -H "X-Bintray-Override:${INPUT_OVERRIDE:-0}" \
             ${UPLOAD_URL})
 
     if [ "$(echo ${RESULT} | jq -r '.message')" != "success" ]; then


### PR DESCRIPTION
Unfortunately I made a typo in the previous patch. Correct syntax in bash is `${parameter:-word}`.